### PR TITLE
use heap to ensure that miners cannot get kicked from the network by being unlucky

### DIFF
--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -112,7 +112,7 @@ def get_oldest_uids(
     for hotkey, uid in shuffled_miner_dict.items():
         shuffled_miner_dict.pop(hotkey) if not validator_condition(uid, infos[uid]) else None
 
-    for hotkey, value in self.miner_heap.items():
+    for hotkey, value in list(self.miner_heap.items()):
         if hotkey not in [hk for hk in shuffled_miner_dict.keys()]:
             self.miner_heap.pop(hotkey)
 
@@ -126,10 +126,10 @@ def get_oldest_uids(
     return uids
 
 
-def get_n_lowest_values(heapdict: heapdict.heapdict, n):
+def get_n_lowest_values(heap_dict: heapdict.heapdict, n):
     lowest_values = []
-    for _ in range(min(n, len(heapdict))):
-        hotkey, ts = heapdict.popitem()
+    for _ in range(min(n, len(heap_dict))):
+        hotkey, ts = heap_dict.popitem()
         lowest_values.append(hotkey)
-        heapdict[hotkey] = int(datetime.utcnow().timestamp())
+        heap_dict[hotkey] = int(datetime.utcnow().timestamp())
     return lowest_values

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -10,7 +10,6 @@ from tensor.protocol import NeuronInfoSynapse
 
 
 DEFAULT_NEURON_INFO = NeuronInfoSynapse()
-uid_distribution_heapdict = heapdict.heapdict()
 
 async def sync_neuron_info(self):
     uids = [
@@ -114,11 +113,11 @@ def get_oldest_uids(
     ]
 
     for uid in all_uids:
-        if uid not in uid_distribution_heapdict:
-            uid_distribution_heapdict[uid] = 0
+        if uid not in self.miner_heap:
+            self.miner_heap[uid] = 0
 
     uids = torch.tensor(
-        get_n_lowest_values(uid_distribution_heapdict, k)
+        get_n_lowest_values(self.miner_heap, k)
     )
     return uids
 

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -101,29 +101,29 @@ def get_oldest_uids(
     hotkeys = list(all_uids_and_hotkeys_dict.keys())
     random.shuffle(hotkeys)
     for hotkey in hotkeys:
-        
+        all_uids_and_hotkeys_dict.move_to_end(hotkey)
     # if this is not randomized, every new validator will have the same mining order in their heap upon first launch,
     # which would likely perpetuate the problem this function solves
 
     infos = {
         uid: self.neuron_info.get(uid, DEFAULT_NEURON_INFO)
-        for hotkey, uid in all_uids_and_hotkeys_dict.items()
+        for uid in all_uids_and_hotkeys_dict.values()
     }
 
     pruned_uids_and_hotkeys = OrderedDict(
-        (hotkey, uid) for hotkey, uid in all_uids_and_hotkeys_ordered.items() if not validator_condition(uid, infos[uid])
+        (hotkey, uid) for hotkey, uid in all_uids_and_hotkeys_dict.items() if not validator_condition(uid, infos[uid])
     )
 
     for hotkey, value in self.miner_heap.items():
-        if hotkey not in [hk for hk in hotkey_to_uid_dict.keys()]:
+        if hotkey not in [hk for hk in pruned_uids_and_hotkeys.keys()]:
             self.miner_heap.pop(hotkey)
 
-    for hotkey in hotkey_to_uid_dict.keys():
+    for hotkey in pruned_uids_and_hotkeys.keys():
         if hotkey not in self.miner_heap:
             self.miner_heap[hotkey] = 0
 
     uids = torch.tensor(
-        hotkey_to_uid_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)
+        pruned_uids_and_hotkeys[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)
     )
     return uids
 

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -125,10 +125,11 @@ def get_oldest_uids(
     for hotkey in disconnected_miner_list:
         self.miner_heap.pop(hotkey)
         self.miner_heap[hotkey] = 0
-
+    bittensor.logging.info("Available miners: " + str(shuffled_miner_dict))
     uids = torch.tensor(
         [shuffled_miner_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)]
     )
+    bittensor.logging.info("Selected miners: " + str(uids))
     return uids
 
 

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -99,7 +99,7 @@ def get_oldest_uids(
     ]
 
     random.shuffle(all_uids)
-    # if this is not randomized, every new validator will have the same mining order upon first launch,
+    # if this is not randomized, every new validator will have the same mining order in their heap upon first launch,
     # which would likely perpetuate the problem this function solves
 
     infos = {

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -130,7 +130,7 @@ def get_oldest_uids(
         self.miner_heap.pop(hotkey)
         self.miner_heap[hotkey] = 0
     bittensor.logging.info("Available miners: " + str(shuffled_miner_dict))
-    bittensor.logging.info("Miner heap: " + str(list(self.miner_heap.keys())))
+    bittensor.logging.info("Miner heap: " + str(list(self.miner_heap.items())))
     uids = torch.tensor(
         [shuffled_miner_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)]
     )

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import heapdict
 import torch
 import random
@@ -91,37 +93,37 @@ def get_oldest_uids(
         def validator_condition(_uid: int, info: NeuronInfoSynapse) -> bool:
             return info.is_validator is False
 
-    all_uids_and_hotkeys = [
-        (uid, self.metagraph.axons[uid].hotkey)
+    all_uids_and_hotkeys_dict = OrderedDict(
+        (self.metagraph.axons[uid].hotkey, uid)
         for uid in range(self.metagraph.n.item())
         if self.metagraph.axons[uid].is_serving
-    ]
-
-    random.shuffle(all_uids_and_hotkeys)
+    )
+    hotkeys = list(all_uids_and_hotkeys_dict.keys())
+    random.shuffle(hotkeys)
+    for hotkey in hotkeys:
+        
     # if this is not randomized, every new validator will have the same mining order in their heap upon first launch,
     # which would likely perpetuate the problem this function solves
 
     infos = {
         uid: self.neuron_info.get(uid, DEFAULT_NEURON_INFO)
-        for uid, hotkey in all_uids_and_hotkeys
+        for hotkey, uid in all_uids_and_hotkeys_dict.items()
     }
 
-    all_uids_and_hotkeys = [
-        uid
-        for uid, hotkey in all_uids_and_hotkeys
-        if validator_condition(uid, infos[uid])
-    ]
+    pruned_uids_and_hotkeys = OrderedDict(
+        (hotkey, uid) for hotkey, uid in all_uids_and_hotkeys_ordered.items() if not validator_condition(uid, infos[uid])
+    )
 
     for hotkey, value in self.miner_heap.items():
-        if hotkey not in [hk for uid, hk in all_uids_and_hotkeys]:
+        if hotkey not in [hk for hk in hotkey_to_uid_dict.keys()]:
             self.miner_heap.pop(hotkey)
 
-    for uid, hotkey in all_uids_and_hotkeys:
+    for hotkey in hotkey_to_uid_dict.keys():
         if hotkey not in self.miner_heap:
             self.miner_heap[hotkey] = 0
 
     uids = torch.tensor(
-        get_n_lowest_values(self.miner_heap, k)
+        hotkey_to_uid_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)
     )
     return uids
 
@@ -129,7 +131,7 @@ def get_oldest_uids(
 def get_n_lowest_values(heapdict: heapdict.heapdict, n):
     lowest_values = []
     for _ in range(min(n, len(heapdict))):
-        key, value = heapdict.popitem()
-        lowest_values.append((key, value))
-        heapdict[key] = int(datetime.utcnow().timestamp())
+        hotkey, ts = heapdict.popitem()
+        lowest_values.append(hotkey)
+        heapdict[hotkey] = int(datetime.utcnow().timestamp())
     return lowest_values

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -117,6 +117,10 @@ def get_oldest_uids(
     for hotkey in invalid_miner_list:
         shuffled_miner_dict.pop(hotkey)
 
+    for hotkey in shuffled_miner_dict.keys():
+        if hotkey not in self.miner_heap:
+            self.miner_heap[hotkey] = 0
+
     disconnected_miner_list = [
         hotkey
         for hotkey in list(shuffled_miner_dict.keys())

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -109,16 +109,22 @@ def get_oldest_uids(
         uid: self.neuron_info.get(uid, DEFAULT_NEURON_INFO)
         for uid in shuffled_miner_dict.values()
     }
-    for hotkey, uid in shuffled_miner_dict.items():
-        shuffled_miner_dict.pop(hotkey) if not validator_condition(uid, infos[uid]) else None
+    invalid_miner_list = [
+        hotkey
+        for hotkey, uid in shuffled_miner_dict.items()
+        if not validator_condition(uid, infos[uid])
+    ]
+    for hotkey in invalid_miner_list:
+        shuffled_miner_dict.pop(hotkey)
 
-    for hotkey, value in list(self.miner_heap.items()):
-        if hotkey not in [hk for hk in shuffled_miner_dict.keys()]:
-            self.miner_heap.pop(hotkey)
-
-    for hotkey in shuffled_miner_dict.keys():
-        if hotkey not in self.miner_heap:
-            self.miner_heap[hotkey] = 0
+    disconnected_miner_list = [
+        hotkey
+        for hotkey in list(shuffled_miner_dict.keys())
+        if hotkey not in [hk for hk in shuffled_miner_dict.keys()]
+    ]
+    for hotkey in disconnected_miner_list:
+        self.miner_heap.pop(hotkey)
+        self.miner_heap[hotkey] = 0
 
     uids = torch.tensor(
         shuffled_miner_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -98,6 +98,10 @@ def get_oldest_uids(
         if self.metagraph.axons[uid].is_serving
     ]
 
+    random.shuffle(all_uids)
+    # if this is not randomized, every new validator will have the same mining order upon first launch,
+    # which would likely perpetuate the problem this function solves
+
     infos = {
         uid: self.neuron_info.get(uid, DEFAULT_NEURON_INFO)
         for uid in all_uids

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -127,7 +127,7 @@ def get_oldest_uids(
         self.miner_heap[hotkey] = 0
 
     uids = torch.tensor(
-        shuffled_miner_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)
+        [shuffled_miner_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)]
     )
     return uids
 

--- a/neuron-selector/neuron_selector/uids.py
+++ b/neuron-selector/neuron_selector/uids.py
@@ -130,6 +130,7 @@ def get_oldest_uids(
         self.miner_heap.pop(hotkey)
         self.miner_heap[hotkey] = 0
     bittensor.logging.info("Available miners: " + str(shuffled_miner_dict))
+    bittensor.logging.info("Miner heap: " + str(list(self.miner_heap.keys())))
     uids = torch.tensor(
         [shuffled_miner_dict[hotkey] for hotkey in get_n_lowest_values(self.miner_heap, k)]
     )

--- a/neuron-selector/setup.py
+++ b/neuron-selector/setup.py
@@ -42,6 +42,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "wombo-bittensor-subnet-tensor",
+        "heapdict==1.0.1",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/validator/validator/main.py
+++ b/validator/validator/main.py
@@ -32,7 +32,7 @@ from starlette import status
 
 from image_generation_protocol.io_protocol import ImageGenerationInputs
 from tensor.protocol import ImageGenerationSynapse, ImageGenerationClientSynapse, NeuronInfoSynapse
-from neuron_selector.uids import get_oldest_uids
+from neuron_selector.uids import get_oldest_uids, get_random_uids
 from tensor.timeouts import CLIENT_REQUEST_TIMEOUT, AXON_REQUEST_TIMEOUT, KEEP_ALIVE_TIMEOUT
 
 # import base validator class which takes care of most of the boilerplate
@@ -189,7 +189,7 @@ class Validator(BaseValidatorNeuron):
         self.update_scores(torch.FloatTensor([0.0] * len(bad_miner_uids)), bad_miner_uids)
 
     async def forward_image(self, synapse: ImageGenerationClientSynapse) -> ImageGenerationClientSynapse:
-        miner_uids = get_oldest_uids(self, k=1, validators=False)
+        miner_uids = get_random_uids(self, k=1, validators=False)
 
         if not len(miner_uids):
             raise HTTPException(

--- a/validator/validator/main.py
+++ b/validator/validator/main.py
@@ -32,7 +32,7 @@ from starlette import status
 
 from image_generation_protocol.io_protocol import ImageGenerationInputs
 from tensor.protocol import ImageGenerationSynapse, ImageGenerationClientSynapse, NeuronInfoSynapse
-from neuron_selector.uids import get_random_uids
+from neuron_selector.uids import get_oldest_uids
 from tensor.timeouts import CLIENT_REQUEST_TIMEOUT, AXON_REQUEST_TIMEOUT, KEEP_ALIVE_TIMEOUT
 
 # import base validator class which takes care of most of the boilerplate
@@ -106,7 +106,7 @@ class Validator(BaseValidatorNeuron):
         - Updating the scores
         """
 
-        miner_uids = get_random_uids(self, k=self.config.neuron.sample_size, validators=False)
+        miner_uids = get_oldest_uids(self, k=self.config.neuron.sample_size, validators=False)
 
         if not len(miner_uids):
             return
@@ -189,7 +189,7 @@ class Validator(BaseValidatorNeuron):
         self.update_scores(torch.FloatTensor([0.0] * len(bad_miner_uids)), bad_miner_uids)
 
     async def forward_image(self, synapse: ImageGenerationClientSynapse) -> ImageGenerationClientSynapse:
-        miner_uids = get_random_uids(self, k=1, validators=False)
+        miner_uids = get_oldest_uids(self, k=1, validators=False)
 
         if not len(miner_uids):
             raise HTTPException(

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -22,6 +22,7 @@ import os.path
 import traceback
 from abc import abstractmethod
 
+import heapdict
 import torch
 import asyncio
 import bittensor as bt
@@ -59,6 +60,8 @@ class BaseValidatorNeuron(BaseNeuron):
         self.serve_axon()
 
         self.neuron_info = {}
+
+        self.miner_heap = heapdict.heapdict()
 
     def serve_axon(self):
         """Serve axon to enable external connections."""
@@ -330,6 +333,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 "step": self.step,
                 "scores": self.scores,
                 "hotkeys": self.hotkeys,
+                "miner_heap": self.miner_heap,
             },
             self.config.neuron.full_path + "/state.pt",
         )
@@ -348,3 +352,4 @@ class BaseValidatorNeuron(BaseNeuron):
         self.step = state["step"]
         self.scores = state["scores"]
         self.hotkeys = state["hotkeys"]
+        self.miner_heap = state["miner_heap"]


### PR DESCRIPTION
adds a heapdict to the uid selection logic for validators. The system randomizes the order of the uids coming from the meta_graph so that any time that new uids are being put into the heap, it is in a randomized order. 