### PR TITLE
miner_heap default if not in the existing validator state

### DIFF
--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -378,4 +378,4 @@ class BaseValidatorNeuron(BaseNeuron):
         self.step = state["step"]
         self.scores = state["scores"]
         self.hotkeys = state["hotkeys"]
-        self.miner_heap = state["miner_heap"]
+        self.miner_heap = state.get("miner_heap", heapdict.heapdict())


### PR DESCRIPTION
bugfix: since this was not a tensor present before the update, it was breaking existing validators. this gives it a default for those updating from a previous version.