### PR TITLE
Use max instead of min for num images to validate

### DIFF
--- a/validator/validator/get_base_weights.py
+++ b/validator/validator/get_base_weights.py
@@ -142,7 +142,7 @@ async def get_base_weight(
     hotkey = keypair.ss58_address
     signature = f"0x{keypair.sign(hotkey).hex()}"
 
-    check_count = min(1, int(len(finished_responses) * 0.125))
+    check_count = max(1, int(len(finished_responses) * 0.125))
 
     scores = await asyncio.gather(*[
         reward(


### PR DESCRIPTION
We had a small bug that would only validate a max of  image from the RPS test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified the calculation in the validation process to ensure a minimum count of checks, enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->