### PR TITLE
Allow specifying image generator API IP

### DIFF
--- a/image-generator/image_generator/main.py
+++ b/image-generator/image_generator/main.py
@@ -80,7 +80,7 @@ def main():
     def healthcheck():
         return datetime.utcnow()
 
-    uvicorn.run(app, host=os.getenv("BIND_IP", "127.0.0.1"), port=int(os.getenv("PORT", str(8001))))
+    uvicorn.run(app, host=os.getenv("BIND_IP", "0.0.0.0"), port=int(os.getenv("PORT", str(8001))))
 
 
 if __name__ == "__main__":

--- a/image-generator/image_generator/main.py
+++ b/image-generator/image_generator/main.py
@@ -82,5 +82,6 @@ def main():
 
     uvicorn.run(app, host=os.getenv("BIND_IP", "127.0.0.1"), port=int(os.getenv("PORT", str(8001))))
 
+
 if __name__ == "__main__":
     main()

--- a/image-generator/image_generator/main.py
+++ b/image-generator/image_generator/main.py
@@ -80,8 +80,7 @@ def main():
     def healthcheck():
         return datetime.utcnow()
 
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", str(8001))))
-
+    uvicorn.run(app, host=os.getenv("BIND_IP", "127.0.0.1"), port=int(os.getenv("PORT", str(8001))))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Update the image generator API to use BIND_IP environment variable (with a default of "127.0.0.1") when running uvicorn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced connectivity and accessibility by modifying the IP address binding in the image generation service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->