### PR TITLE
Increase penalty for failed requests, and make it cleaner

### DIFF
--- a/validator/validator/miner_metrics.py
+++ b/validator/validator/miner_metrics.py
@@ -59,6 +59,7 @@ The max percentage of failures acceptable before stopping
 ValidatableResponse: TypeAlias = tuple[ImageGenerationSynapse, ImageGenerationInputs]
 
 WORDS = [word for word, tag in pos_tag(words.words(), tagset='universal') if tag == "ADJ" or tag == "NOUN"]
+REQUEST_INCENTIVE = 0.000976562
 
 
 def generate_random_prompt():
@@ -82,9 +83,9 @@ class MinerMetrics(BaseModel):
         success_factor = pow(1 - self.error_rate, 2)
 
         return (
-            concurrency_factor * similarity_factor * success_factor +
-            self.successful_user_requests / 1024 -
-            self.failed_user_requests / 512
+                concurrency_factor * similarity_factor * success_factor +
+                self.successful_user_requests * REQUEST_INCENTIVE -
+                (self.failed_user_requests * REQUEST_INCENTIVE * 16)
         )
 
 

--- a/validator/validator/miner_metrics.py
+++ b/validator/validator/miner_metrics.py
@@ -85,7 +85,7 @@ class MinerMetrics(BaseModel):
         return (
                 concurrency_factor * similarity_factor * success_factor +
                 self.successful_user_requests * REQUEST_INCENTIVE -
-                (self.failed_user_requests * REQUEST_INCENTIVE * 16)
+                (self.failed_user_requests * REQUEST_INCENTIVE * 8)
         )
 
 

--- a/validator/validator/miner_metrics.py
+++ b/validator/validator/miner_metrics.py
@@ -59,7 +59,7 @@ The max percentage of failures acceptable before stopping
 ValidatableResponse: TypeAlias = tuple[ImageGenerationSynapse, ImageGenerationInputs]
 
 WORDS = [word for word, tag in pos_tag(words.words(), tagset='universal') if tag == "ADJ" or tag == "NOUN"]
-REQUEST_INCENTIVE = 0.000976562
+REQUEST_INCENTIVE = 0.0001
 
 
 def generate_random_prompt():


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new constant `REQUEST_INCENTIVE` to standardize how incentives are calculated for both successful and failed requests.
- Updated the `get_weight` method to utilize the new constant, changing the formula to increase the penalty for failed requests while maintaining a cleaner and more consistent calculation approach.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner_metrics.py</strong><dd><code>Standardize Request Incentives and Modify Weight Calculation</code></dd></summary>
<hr>
      
validator/validator/miner_metrics.py

<li>Introduced a new constant <code>REQUEST_INCENTIVE</code> to standardize the <br>incentive calculation.<br> <li> Modified the weight calculation formula in <code>get_weight</code> method to use <br>the new <code>REQUEST_INCENTIVE</code> for both successful and failed user <br>requests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/womboai/wombo-bittensor-subnet/pull/45/files#diff-ea92a5900c158a01c5824b1a97b28474d530da76ef4818da4ac39c31f79d113e">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new incentive mechanism to adjust miner metrics based on user request success rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->