### PR TITLE
Fix TCPConnector limit

### DIFF
--- a/validator/validator/miner_metrics.py
+++ b/validator/validator/miner_metrics.py
@@ -307,7 +307,6 @@ async def set_miner_metrics(validator, uid: int):
 
     dendrite: bt.dendrite = validator.periodic_check_dendrite
     session = await dendrite.session
-    connector_changed = False
 
     while True:
         bt.logging.info(f"\tTesting {count} requests")
@@ -332,8 +331,6 @@ async def set_miner_metrics(validator, uid: int):
             # Accessing private variables but can't find another way to do this
             await session.close()
             session._connector = TCPConnector(limit=count)
-
-            connector_changed = True
 
         responses: list[ImageGenerationSynapse] = list(
             await asyncio.gather(
@@ -391,10 +388,6 @@ async def set_miner_metrics(validator, uid: int):
             break
 
         count *= 2
-
-    if connector_changed:
-        await session.close()
-        session._connector = TCPConnector()
 
     check_count = max(1, int(len(finished_responses) * 0.125))
 

--- a/validator/validator/miner_metrics.py
+++ b/validator/validator/miner_metrics.py
@@ -27,7 +27,7 @@ from typing import Any, TypeAlias, Annotated, Optional
 import bittensor as bt
 import nltk
 import torch
-from aiohttp import ClientSession, BasicAuth
+from aiohttp import ClientSession, BasicAuth, TCPConnector
 from pydantic import BaseModel, Field
 from substrateinterface import Keypair
 from torch import Tensor
@@ -305,6 +305,9 @@ async def set_miner_metrics(validator, uid: int):
 
     finished_responses: list[ValidatableResponse] = []
 
+    dendrite: bt.dendrite = validator.periodic_check_dendrite
+    session = await dendrite.session
+
     while True:
         bt.logging.info(f"\tTesting {count} requests")
 
@@ -323,6 +326,10 @@ async def set_miner_metrics(validator, uid: int):
             get_inputs()
             for _ in range(count)
         ]
+
+        if count > session.connector.limit:
+            # Accessing private variables but can't find another way to do this
+            session._connector = TCPConnector(limit=count)
 
         responses: list[ImageGenerationSynapse] = list(
             await asyncio.gather(
@@ -380,6 +387,8 @@ async def set_miner_metrics(validator, uid: int):
             break
 
         count *= 2
+
+    session._connector = TCPConnector()
 
     check_count = max(1, int(len(finished_responses) * 0.125))
 


### PR DESCRIPTION
## **User description**
Previously, the `100` limit of the TCPConnector caused 128+ request count to have a noticable pause on the validator side that affected the miner's incentive


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Adjusted TCPConnector usage in `miner_metrics.py` to dynamically handle request limits based on the count, enhancing performance and reliability.
- Added a mechanism to close and reset the session's connector when the request count surpasses the predefined limit, preventing pauses and potential request drops.
- Utilized the updated dendrite session for ongoing operations, ensuring consistency and efficiency in handling requests.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner_metrics.py</strong><dd><code>Enhance TCPConnector Handling in Miner Metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
validator/validator/miner_metrics.py

<li>Introduced TCPConnector to handle dynamic request limits.<br> <li> Added logic to reset the session's connector if the request count <br>exceeds the current limit.<br> <li> Ensured the session uses the updated dendrite session.<br>


</details>
    

  </td>
  <td><a href="https://github.com/womboai/wombo-bittensor-subnet/pull/51/files#diff-ea92a5900c158a01c5824b1a97b28474d530da76ef4818da4ac39c31f79d113e">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced network handling by adjusting session connector limits to improve request management efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->